### PR TITLE
Changes credentials transmission

### DIFF
--- a/FlightStats/FlightStats.php
+++ b/FlightStats/FlightStats.php
@@ -60,4 +60,15 @@ class FlightStats extends RestClient
         return new Methods\Airports($this->config, $api);
     }
 
+    /**
+     *
+     * @return \Spiiicy\Bundle\FlightStatsBundle\FlightStats\Methods\Alerts
+     */
+    public function getAlerts()
+    {
+        $api = $this->apiUrl . '';
+        
+        return new Methods\Alerts($this->config, $api);
+    }
+
 }

--- a/FlightStats/FlightStats.php
+++ b/FlightStats/FlightStats.php
@@ -66,7 +66,7 @@ class FlightStats extends RestClient
      */
     public function getAlerts()
     {
-        $api = $this->apiUrl . '';
+        $api = $this->apiUrl . 'alerts/rest/v1/json/';
         
         return new Methods\Alerts($this->config, $api);
     }

--- a/FlightStats/FlightStatsAPIException.php
+++ b/FlightStats/FlightStatsAPIException.php
@@ -5,7 +5,7 @@ namespace Spiiicy\Bundle\FlightStatsBundle\FlightStats;
 class FlightStatsAPIException extends \Exception {
 
     public function __construct($data) {
-        parent::__construct(sprintf('FlightStats API error : [ %s ] %s , code = %s', $data['name'], $data['error'], $data['code']),$data['code']);
+        parent::__construct(sprintf('FlightStats API error : [ %s ] %s , code = %s', $data['error']['errorCode'], $data['error']['errorMessage'], $data['error']['httpStatusCode']), $data['error']['httpStatusCode']);
     }
 
 }

--- a/FlightStats/Methods/Airlines.php
+++ b/FlightStats/Methods/Airlines.php
@@ -8,22 +8,46 @@ use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
 class Airlines extends RestClient {
 
     /**
+     * Returns a listing of all airlines registered by FlightStats
+     *
+     * @link https://developer.flightstats.com/api-docs/airlines/v1
+     * @return JSON
+     * @throws \Exception
+     * @throws FlightStatsAPIException
+     */
+    public function getAllAirlines() {
+
+        $apiCall = sprintf('all');
+
+        $res = $this->request($apiCall);
+
+        $code = $res->getStatusCode();
+        $json = json_decode($res->getBody()->getContents(), true);
+
+        if (isset($json['error'])) {
+            throw new FlightStatsAPIException($json);
+        } else {
+            return isset($json) ? $json : false;
+        }
+    }
+
+    /**
      * Returns a listing of currently active airlines
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/airlines/v1
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
     public function getActiveAirlines() {
-        
+
         $apiCall = sprintf('active');
 
         $res = $this->request($apiCall);
 
         $code = $res->getStatusCode();
         $json = json_decode($res->getBody()->getContents(), true);
-        
+
         if (isset($json['error'])) {
             throw new FlightStatsAPIException($json);
         } else {

--- a/FlightStats/Methods/Airports.php
+++ b/FlightStats/Methods/Airports.php
@@ -8,22 +8,46 @@ use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
 class Airports extends RestClient {
 
     /**
+     * Returns a listing of all airports registered by FlightStats
+     *
+     * @link https://developer.flightstats.com/api-docs/airports/v1
+     * @return JSON
+     * @throws \Exception
+     * @throws FlightStatsAPIException
+     */
+    public function getAllAirports() {
+
+        $apiCall = sprintf('all');
+
+        $res = $this->request($apiCall);
+
+        $code = $res->getStatusCode();
+        $json = json_decode($res->getBody()->getContents(), true);
+
+        if (isset($json['error'])) {
+            throw new FlightStatsAPIException($json);
+        } else {
+            return isset($json) ? $json : false;
+        }
+    }
+
+    /**
      * Returns a listing of currently active airports
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/airports/v1
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
     public function getActiveAirports() {
-        
+
         $apiCall = sprintf('active');
 
         $res = $this->request($apiCall);
 
         $code = $res->getStatusCode();
         $json = json_decode($res->getBody()->getContents(), true);
-        
+
         if (isset($json['error'])) {
             throw new FlightStatsAPIException($json);
         } else {

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -9,6 +9,38 @@ class Alerts extends RestClient
 {
 
     /**
+     * Returns at most the last thousand Alert Rule IDs. 
+     * See the alternative form of this to specify the max Rule ID, which allows for iteration over all Rule IDs.
+     * 
+     * @link https://developer.flightstats.com/api-docs/alerts/v1
+     * @param string $rule_id
+     * @return JSON
+     * @throws \Exception
+     * @throws FlightStatsAPIException
+     */
+    public function listAlert() {
+
+        $apiCall = sprintf('list');
+
+        $res = $this->request($apiCall, [
+                "query" => [
+                    "appId" => $this->config['app_id'],
+                    "appKey" => $this->config['app_key']
+                ]
+            ]);
+
+        $code = $res->getStatusCode();
+        $json = json_decode($res->getBody()->getContents(), true);
+        
+        if (isset($json['error'])) {
+            throw new FlightStatsAPIException($json);
+        } else {
+            return isset($json) ? $json : false;
+        }
+
+    }
+
+    /**
      * Create a flight rule to be monitored for a specific flight departing from an airport on the given day. 
      * Returns the fully constructed flight rule that was created.
      * 

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Spiiicy\Bundle\FlightStatsBundle\FlightStats\Methods;
+
+use Spiiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
+use Spiiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
+
+class Alerts extends RestClient 
+{
+
+    /**
+     * Create a flight rule to be monitored for a specific flight departing from an airport on the given day. 
+     * Returns the fully constructed flight rule that was created.
+     * 
+     * @link https://developer.flightstats.com/api-docs/alerts/v1
+     * @param string $carrier
+     * @param string $number 
+     * @param \DateTime $departure
+     * @return JSON
+     * @throws \Exception
+     * @throws FlightStatsAPIException
+     */
+    public function createRuleByDeparture(
+        $carrier, 
+        $flight, 
+        $departure_airport, 
+        $departure, 
+        $events = "dep,can,div,preDep30,depLate30,depDelay,depGate"
+    ) {
+
+        $params = array(
+            'carrier' => $carrier,
+            'flight' => $flight,
+            'departureAirport' => $departure_airport,
+            'events' => $events,
+            'year' => $departure->format('Y'),
+            'month' => $departure->format('m'),
+            'day' => $departure->format('d'),
+        );
+
+        // $apiCall = sprintf('create/%s/%s/from/%s/departing/%d/%d/%d?type=JSON&events=%s&deliverTo=%s', 
+        $apiCall = sprintf('create/%s/%s/from/%s/departing/%d/%d/%d', 
+                $params['carrier'], 
+                $params['flight'], 
+                $params['departureAirport'], 
+                $params['year'], 
+                $params['month'], 
+                $params['day']
+            );
+
+        $res = $this->request($apiCall, 
+            [
+                "query" => ["type" => "JSON", "events" => $events, "deliverTo" => $this->config['deliver_to']]
+            ]
+        );
+
+        $code = $res->getStatusCode();
+        $json = json_decode($res->getBody()->getContents(), true);
+        
+        if (isset($json['error'])) {
+            throw new FlightStatsAPIException($json);
+        } else {
+            return isset($json) ? $json : false;
+        }
+
+    }
+
+}

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -97,6 +97,37 @@ class Alerts extends RestClient
     }
 
     /**
+     * Returns the flight rule that was previously created given a rule ID.
+     * 
+     * @link https://developer.flightstats.com/api-docs/alerts/v1
+     * @param string $rule_id
+     * @return JSON
+     * @throws \Exception
+     * @throws FlightStatsAPIException
+     */
+    public function getAlert($rule_id) {
+
+        $apiCall = sprintf('get/%d', $rule_id);
+
+        $res = $this->request($apiCall, [
+                "query" => [
+                    "appId" => $this->config['app_id'],
+                    "appKey" => $this->config['app_key']
+                ]
+            ]);
+
+        $code = $res->getStatusCode();
+        $json = json_decode($res->getBody()->getContents(), true);
+        
+        if (isset($json['error'])) {
+            throw new FlightStatsAPIException($json);
+        } else {
+            return isset($json) ? $json : false;
+        }
+
+    }
+
+    /**
      * Deletes a flight rule that was previously created given a rule ID. Returns the flight rule that was deleted.
      * Note that once deleted any subsequent calls with the same ID will return a rule not found exception.
      * 

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -56,8 +56,10 @@ class Alerts extends RestClient
         $flight, 
         $departure_airport, 
         $departure, 
-        $events = "dep,can,div,preDep30,depLate30,depDelay,depGate"
+        $events = "dep,arr,can,div,preDep30,depLate30,depDelay,depGate"
     ) {
+
+        $alert_name = sprintf('%s_%s_%s_%d', $carrier, $flight, $departure_airport, $departure->format('Y-m-d'));
 
         $params = array(
             'carrier' => $carrier,
@@ -68,6 +70,7 @@ class Alerts extends RestClient
             'month' => $departure->format('m'),
             'day' => $departure->format('d'),
         );
+
 
         $apiCall = sprintf('create/%s/%s/from/%s/departing/%d/%d/%d', 
                 $params['carrier'], 
@@ -80,7 +83,12 @@ class Alerts extends RestClient
 
         $res = $this->request($apiCall, 
             [
-                "query" => ["type" => "JSON", "events" => $events, "deliverTo" => $this->config['deliver_to']]
+                "query" => [
+                    "type" => "JSON", 
+                    "name" => $alert_name,
+                    "events" => $events, 
+                    "deliverTo" => $this->config['deliver_to']
+                ]
             ]
         );
 

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -13,7 +13,6 @@ class Alerts extends RestClient
      * See the alternative form of this to specify the max Rule ID, which allows for iteration over all Rule IDs.
      * 
      * @link https://developer.flightstats.com/api-docs/alerts/v1
-     * @param string $rule_id
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -38,7 +38,6 @@ class Alerts extends RestClient
             'day' => $departure->format('d'),
         );
 
-        // $apiCall = sprintf('create/%s/%s/from/%s/departing/%d/%d/%d?type=JSON&events=%s&deliverTo=%s', 
         $apiCall = sprintf('create/%s/%s/from/%s/departing/%d/%d/%d', 
                 $params['carrier'], 
                 $params['flight'], 

--- a/FlightStats/Methods/Alerts.php
+++ b/FlightStats/Methods/Alerts.php
@@ -65,4 +65,35 @@ class Alerts extends RestClient
 
     }
 
+    /**
+     * Deletes a flight rule that was previously created given a rule ID. Returns the flight rule that was deleted.
+     * Note that once deleted any subsequent calls with the same ID will return a rule not found exception.
+     * 
+     * @link https://developer.flightstats.com/api-docs/alerts/v1
+     * @param string $rule_id
+     * @return JSON
+     * @throws \Exception
+     * @throws FlightStatsAPIException
+     */
+    public function deleteByRuleId($rule_id) {
+
+        $params = array(
+            'rule_id' => $rule_id
+        );
+
+        $apiCall = sprintf('delete/%d', $rule_id);
+
+        $res = $this->request($apiCall);
+
+        $code = $res->getStatusCode();
+        $json = json_decode($res->getBody()->getContents(), true);
+        
+        if (isset($json['error'])) {
+            throw new FlightStatsAPIException($json);
+        } else {
+            return isset($json) ? $json : false;
+        }
+
+    }
+
 }

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -31,7 +31,7 @@ class RestClient
     protected function request($apiCall, $params = array())
     {
         $client = new Client([
-            'base_url' => [$this->apiUrl, ['version' => 'v1.1']],
+            'base_url' => [$this->apiUrl, ['version' => 'v1']],
             'defaults' => ['headers' => [
                 'appId' => $this->config['app_id'],
                 'appKey' => $this->config['app_key'],

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -54,6 +54,7 @@ class RestClient
         }));
 
         $client = new Client([
+            'debug'    => filter_var(@$this->config['debug'], FILTER_VALIDATE_BOOLEAN),
             'base_uri' => $this->apiUrl,
             'handler'  => $handler,
             'headers'  => [

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -39,7 +39,7 @@ class RestClient
             ]],
         ]);
 
-        return $client->get($apiCall, $params);
+        return $client->get($this->apiUrl . $apiCall, $params);
     }
 
 }

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -31,15 +31,17 @@ class RestClient
     protected function request($apiCall, $params = array())
     {
         $client = new Client([
-            'base_url' => [$this->apiUrl, ['version' => 'v1']],
+            // 'debug' => true,
+            'base_uri' => $this->apiUrl,
             'defaults' => ['headers' => [
                 'appId' => $this->config['app_id'],
                 'appKey' => $this->config['app_key'],
                 'Content-Type' => 'application/json;charset=UTF-8',
             ]],
         ]);
-
-        return $client->get($this->apiUrl . $apiCall, $params);
+        $params['headers']["appId"] = $this->config['app_id'];
+        $params['headers']["appKey"] = $this->config['app_key'];
+        return $client->get($apiCall, $params);
     }
 
 }

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -3,6 +3,10 @@
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
 
 class RestClient
 {
@@ -22,7 +26,7 @@ class RestClient
     }
 
     /**
-     * Prepare the curl request
+     * Prepare the Guzzle request
      *
      * @param string $apiCall the API call function
      * @param array $params Parameters (Optional)
@@ -30,16 +34,33 @@ class RestClient
      */
     protected function request($apiCall, $params = array())
     {
+        $handler = HandlerStack::create();
+
+        $appId  = $this->config['app_id'];
+        $appKey = $this->config['app_key'];
+
+        $handler->unshift(Middleware::mapRequest(function (RequestInterface $request) use ($appId, $appKey) {
+            return $request->withUri(
+                Uri::withQueryValue(
+                    Uri::withQueryValue(
+                        $request->getUri(),
+                        'appKey',
+                        $appKey
+                        ),
+                    'appId',
+                    $appId
+                )
+            );
+        }));
+
         $client = new Client([
             'base_uri' => $this->apiUrl,
-            'headers' => [
-                'appId' => $this->config['app_id'],
-                'appKey' => $this->config['app_key'],
+            'handler'  => $handler,
+            'headers'  => [
                 'Content-Type' => 'application/json;charset=UTF-8',
             ],
         ]);
 
-        return $client->request('GET', $apiCall);
+        return $client->get($apiCall, $params);
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/framework-bundle": "2.*",
-        "guzzlehttp/guzzle": "5.3"
+        "guzzlehttp/guzzle": "6.1.0"
     },
 
     "autoload": {


### PR DESCRIPTION
After a sort of dialogue of the deaf with support, they dropped the following.

> The engineers confirmed that sending appId/appKey as header parameters is a deprecated feature with no guarantee of future support.

This PR sets appId and appKey as default query string parameters rather than header values.

Also, this adds all airline and all airports retrieval possibility and (thanks to @adkarta) alerts handling, as well as debug option.

**Note**: merging this makes closing #2 possible without merging (done in this PR).