### PR TITLE
Feature/fix return type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,10 +15,15 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('spiicy_flight_stats');
+        $treeBuilder = new TreeBuilder('spiicy_flight_stats');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('spiicy_flight_stats');
+        }
 
         $rootNode->children()
             ->scalarNode('app_id')->isRequired()->cannotBeEmpty()->end()

--- a/DependencyInjection/SpiicyFlightStatsExtension.php
+++ b/DependencyInjection/SpiicyFlightStatsExtension.php
@@ -2,10 +2,10 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -17,13 +17,13 @@ class SpiicyFlightStatsExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
-        $container->setParameter('spiicy_flight_stats.config',$config);
+        $container->setParameter('spiicy_flight_stats.config', $config);
     }
 }

--- a/FlightStats/FlightStats.php
+++ b/FlightStats/FlightStats.php
@@ -2,11 +2,8 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats;
 
-use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
-
 class FlightStats extends RestClient
 {
-
     protected $config;
     protected $apiUrl;
 
@@ -59,5 +56,4 @@ class FlightStats extends RestClient
         
         return new Methods\Airports($this->config, $api);
     }
-
 }

--- a/FlightStats/FlightStatsAPIException.php
+++ b/FlightStats/FlightStatsAPIException.php
@@ -2,10 +2,10 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats;
 
-class FlightStatsAPIException extends \Exception {
-
-    public function __construct($data) {
+class FlightStatsAPIException extends \Exception
+{
+    public function __construct($data)
+    {
         parent::__construct(sprintf('FlightStats API error : [ %s ] %s, code = %s', $data['error']['httpStatusCode'], $data['error']['errorMessage'], $data['error']['errorId']), $data['error']['httpStatusCode']);
     }
-
 }

--- a/FlightStats/Methods/Airlines.php
+++ b/FlightStats/Methods/Airlines.php
@@ -2,21 +2,21 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats\Methods;
 
-use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
+use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 
-class Airlines extends RestClient {
-
+class Airlines extends RestClient
+{
     /**
      * Returns a listing of currently active airlines
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/airlines/v1
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function getActiveAirlines() {
-        
+    public function getActiveAirlines()
+    {
         $apiCall = sprintf('active');
 
         $res = $this->request($apiCall);
@@ -30,5 +30,4 @@ class Airlines extends RestClient {
             return isset($json) ? $json : false;
         }
     }
-
 }

--- a/FlightStats/Methods/Airports.php
+++ b/FlightStats/Methods/Airports.php
@@ -2,21 +2,21 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats\Methods;
 
-use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
+use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 
-class Airports extends RestClient {
-
+class Airports extends RestClient
+{
     /**
      * Returns a listing of currently active airports
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/airports/v1
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function getActiveAirports() {
-        
+    public function getActiveAirports()
+    {
         $apiCall = sprintf('active');
 
         $res = $this->request($apiCall);
@@ -30,5 +30,4 @@ class Airports extends RestClient {
             return isset($json) ? $json : false;
         }
     }
-
 }

--- a/FlightStats/Methods/FlightStatus.php
+++ b/FlightStats/Methods/FlightStatus.php
@@ -2,31 +2,31 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats\Methods;
 
-use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
+use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 
-class FlightStatus extends RestClient {
-
+class FlightStatus extends RestClient
+{
     /**
      * Get the Flight Statuses for the given Carrier and Flight Number that arrived on the given date.
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/flightstatus/v2/flight
      * @param string $carrier
-     * @param string $number 
+     * @param string $number
      * @param \DateTime $arrival
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function statusByFlightNumber($carrier, $flight, $arrival) {
-        
-        $params = array(
+    public function statusByFlightNumber($carrier, $flight, $arrival)
+    {
+        $params = [
             'carrier' => $carrier,
             'flight' => $flight,
             'year' => $arrival->format('Y'),
             'month' => $arrival->format('m'),
             'day' => $arrival->format('d'),
-        );
+        ];
 
         $apiCall = sprintf('flight/status/%s/%s/arr/%d/%d/%d', $params['carrier'], $params['flight'], $params['year'], $params['month'], $params['day']);
 
@@ -44,24 +44,24 @@ class FlightStatus extends RestClient {
 
     /**
      * Returns the positional tracks of flights, with a given carrier and flight number, arriving or having arrived on the given date
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/flightstatus/v2/flight
      * @param string $carrier
-     * @param string $number 
+     * @param string $number
      * @param \DateTime $arrival
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function trackByFlightNumber($carrier, $flight, $arrival) {
-        
-        $params = array(
+    public function trackByFlightNumber($carrier, $flight, $arrival)
+    {
+        $params = [
             'carrier' => $carrier,
             'flight' => $flight,
             'year' => $arrival->format('Y'),
             'month' => $arrival->format('m'),
             'day' => $arrival->format('d'),
-        );
+        ];
 
         $apiCall = sprintf('flight/tracks/%s/%s/arr/%d/%d/%d', $params['carrier'], $params['flight'], $params['year'], $params['month'], $params['day']);
 
@@ -76,5 +76,4 @@ class FlightStatus extends RestClient {
             return isset($json) ? $json : false;
         }
     }
-
 }

--- a/FlightStats/Methods/Schedules.php
+++ b/FlightStats/Methods/Schedules.php
@@ -2,31 +2,31 @@
 
 namespace Spiicy\Bundle\FlightStatsBundle\FlightStats\Methods;
 
-use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStatsAPIException;
+use Spiicy\Bundle\FlightStatsBundle\FlightStats\RestClient;
 
-class Schedules extends RestClient {
-
+class Schedules extends RestClient
+{
     /**
      * Scheduled Flight(s) by carrier and flight number, arriving on the given date.
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/flightstatus/v2/flight
      * @param string $carrier
-     * @param string $number 
+     * @param string $number
      * @param \DateTime $arrival
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function scheduleArrivalByFlightNumber($carrier, $flight, $arrival) {
-        
-        $params = array(
+    public function scheduleArrivalByFlightNumber($carrier, $flight, $arrival)
+    {
+        $params = [
             'carrier' => $carrier,
             'flight' => $flight,
             'year' => $arrival->format('Y'),
             'month' => $arrival->format('m'),
             'day' => $arrival->format('d'),
-        );
+        ];
 
         $apiCall = sprintf('flight/%s/%s/arriving/%d/%d/%d', $params['carrier'], $params['flight'], $params['year'], $params['month'], $params['day']);
 
@@ -44,24 +44,24 @@ class Schedules extends RestClient {
 
     /**
      * Scheduled Flight(s) by carrier and flight number, departing on the given date.
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/flightstatus/v2/flight
      * @param string $carrier
-     * @param string $number 
+     * @param string $number
      * @param \DateTime $departure
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function scheduleDepartureByFlightNumber($carrier, $flight, $departure) {
-        
-        $params = array(
+    public function scheduleDepartureByFlightNumber($carrier, $flight, $departure)
+    {
+        $params = [
             'carrier' => $carrier,
             'flight' => $flight,
             'year' => $departure->format('Y'),
             'month' => $departure->format('m'),
             'day' => $departure->format('d'),
-        );
+        ];
 
         $apiCall = sprintf('flight/%s/%s/departing/%d/%d/%d', $params['carrier'], $params['flight'], $params['year'], $params['month'], $params['day']);
 
@@ -79,24 +79,24 @@ class Schedules extends RestClient {
 
     /**
      * Returns the positional tracks of flights, with a given carrier and flight number, arriving or having arrived on the given date
-     * 
+     *
      * @link https://developer.flightstats.com/api-docs/flightstatus/v2/flight
      * @param string $carrier
-     * @param string $number 
+     * @param string $number
      * @param \DateTime $arrival
      * @return JSON
      * @throws \Exception
      * @throws FlightStatsAPIException
      */
-    public function trackByFlightNumber($carrier, $flight, $arrival) {
-        
-        $params = array(
+    public function trackByFlightNumber($carrier, $flight, $arrival)
+    {
+        $params = [
             'carrier' => $carrier,
             'flight' => $flight,
             'year' => $arrival->format('Y'),
             'month' => $arrival->format('m'),
             'day' => $arrival->format('d'),
-        );
+        ];
 
         $apiCall = sprintf('flight/tracks/%s/%s/arr/%d/%d/%d', $params['carrier'], $params['flight'], $params['year'], $params['month'], $params['day']);
 
@@ -111,5 +111,4 @@ class Schedules extends RestClient {
             return isset($json) ? $json : false;
         }
     }
-
 }

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -25,7 +25,6 @@ class RestClient
      *
      * @param string $apiCall the API call function
      * @param array $params Parameters (Optional)
-     * @return array
      */
     protected function request($apiCall, $params = [])
     {

--- a/FlightStats/RestClient.php
+++ b/FlightStats/RestClient.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Client;
 
 class RestClient
 {
-
     protected $config;
     protected $apiUrl;
 
@@ -28,7 +27,7 @@ class RestClient
      * @param array $params Parameters (Optional)
      * @return array
      */
-    protected function request($apiCall, $params = array())
+    protected function request($apiCall, $params = [])
     {
         $client = new Client([
             'base_uri' => $this->apiUrl,
@@ -41,5 +40,4 @@ class RestClient
 
         return $client->request('GET', $apiCall);
     }
-
 }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -17,4 +17,21 @@ $flightStats = $this->container->get('spiicy_flightstats');
 $schedule = $flightStats->getSchedules()->scheduleByFlightNumber('AC', '1857', new \DateTime('2015-06-01'));
 ```
 
+or use [Symfony's Autowiring feature](https://symfony.com/doc/current/service_container/autowiring.html)
 
+```php
+// ...
+use Spiicy\Bundle\FlightStatsBundle\FlightStats\FlightStats;
+// ...
+
+class MyOwnServiceOrController
+{
+  public function __construct(private readonly FlightStats $flightStats) {
+  }
+
+  public function test(): void {
+    $schedule = $this->flightStats->getSchedules()->scheduleByFlightNumber('AC', '1857', new \DateTime('2015-06-01'));
+    $airlines = $this->flightStats->getAirlines()->getActiveAirlines();
+  }
+}
+```

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -27,13 +27,20 @@ public function registerBundles()
 }
 ```
 
+alternatively in Symfony 5+, register in config/bundles.php
+
+```php
+// ...
+    Spiicy\Bundle\FlightStatsBundle\SpiicyFlightStatsBundle::class => ['all' => true],
+// ...
+```
 
 ## Config
 
 Add the following lines:
 
 ``` yml
-// app/config/config.yml
+// config/packages/spiicy_flight_stats.yaml
 spiicy_flight_stats:
     app_id: <your id>
     app_key: <your key>

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "spiicy/flightstats-bundle",
     "type": "symfony-bundle",
-	"version": "1.2.4",
+	"version": "1.2.5",
     "description": "This Bundle provides a wrapper for the FlightStats API",
     "keywords": ["rest", "api", "flight", "flightstats"],
     "homepage": "http://spiicy.io",
@@ -15,8 +15,8 @@
 
     "require": {
         "php": ">=5.4",
-        "symfony/framework-bundle": ">=2.7||~3.0||~4.0",
-        "guzzlehttp/guzzle": "^6.2"
+        "symfony/framework-bundle": ">=2.7||~3.0||~4.0||~5.0||~6.0",
+        "guzzlehttp/guzzle": "^6|^7"
     },
 
     "autoload": {


### PR DESCRIPTION
Guzzle Client returns with `\Psr\Http\Message\ResponseInterface` instead of `array`.
Leaving the inherited return type for proper type hinting.